### PR TITLE
Remove tracebacks from SOPGPy by default

### DIFF
--- a/pgpy/sopgpy.py
+++ b/pgpy/sopgpy.py
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import io
 import os
+import sys
 import codecs
 import logging
 import packaging.version
@@ -691,6 +692,7 @@ class SOPGPy(sop.StatelessOpenPGP):
 
 
 def main() -> None:
+    sys.tracebacklimit = int(os.environ.get('TRACEBACKLIMIT', 0))
     sop = SOPGPy()
     sop.dispatch()
 


### PR DESCRIPTION
The tracebacks bloat the file size of the Interoperability Test Suite and often aren't very useful.

They can be enabled again by setting the `TRACEBACKLIMIT` environment variable to a positive integer (normal Python default is 1000).

(See also https://gitlab.com/sequoia-pgp/openpgp-interoperability-test-suite/-/merge_requests/101.)